### PR TITLE
修正README.md中示例错误代码

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ if err := pinger.SetRecvMode("afpacket"); err != nil{
 }
 
 // Set afpacket recv mode options
-if recvOpts, err := AfPacketRecvOptions(2, 256, 128, "eth1", 100*time.Millsecond); err != nil{
+if recvOpts, err := AfPacketRecvOptions(2, 128, "eth1", 100*time.Millsecond); err != nil{
     logger.Fatalln(err)
-} else if err := pinger.SetOptions(recvOpts) {
+} else if err := pinger.SetOptions(recvOpts); err != nil {
     logger.Fatalln(err)
 }
 


### PR DESCRIPTION
1. SetOptions 返回err未判断及使用；
2. AfPacketRecvOptions函数调用参数列表错误；